### PR TITLE
sort issues before migrating them

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -188,9 +188,9 @@ def migrate_issues_cmd(source_repo, dest_repo):
     gh = new_gh(token)
     gh_repo = gh.get_repo(dest_repo)
     repo_id = gh_repo.raw_data['node_id']
-    
+
     issues = gh.search_issues(f'is:issue state:open repo:{source_repo}')
-    for issue in issues:
+    for issue in sorted(issues, key=lambda i: i.number):
         issue_id = issue.raw_data['node_id']
         new_issue_number = transfer_issue(token, issue_id, repo_id)
         new_issue = gh_repo.get_issue(new_issue_number)


### PR DESCRIPTION
This preserve the original order of issues in the new repo.

```console
$ python3.11 migrate.py issues   --source-repo Jorropo/test-migration  --dest-repo Jorropo/test-migration-2
Transferred issue from https://github.com/Jorropo/test-migration/issues/1 to https://github.com/Jorropo/test-migration-2/issues/1
Transferred issue from https://github.com/Jorropo/test-migration/issues/2 to https://github.com/Jorropo/test-migration-2/issues/2
Transferred issue from https://github.com/Jorropo/test-migration/issues/3 to https://github.com/Jorropo/test-migration-2/issues/3
Transferred issue from https://github.com/Jorropo/test-migration/issues/4 to https://github.com/Jorropo/test-migration-2/issues/4
Transferred issue from https://github.com/Jorropo/test-migration/issues/5 to https://github.com/Jorropo/test-migration-2/issues/5
Transferred issue from https://github.com/Jorropo/test-migration/issues/6 to https://github.com/Jorropo/test-migration-2/issues/6
Transferred issue from https://github.com/Jorropo/test-migration/issues/7 to https://github.com/Jorropo/test-migration-2/issues/7
Transferred issue from https://github.com/Jorropo/test-migration/issues/8 to https://github.com/Jorropo/test-migration-2/issues/8
Transferred issue from https://github.com/Jorropo/test-migration/issues/9 to https://github.com/Jorropo/test-migration-2/issues/9
Transferred issue from https://github.com/Jorropo/test-migration/issues/10 to https://github.com/Jorropo/test-migration-2/issues/10
Transferred issue from https://github.com/Jorropo/test-migration/issues/11 to https://github.com/Jorropo/test-migration-2/issues/11
```